### PR TITLE
Made zicht:messages:load less verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 4.1.2 - 2020-05-22
+### Fixed
+- Made the `zicht:messages:load` command significantly less verbose
+
 ## 4.1.1 - 2020-05-15
 ### Changed
 - Switched from PSR-0 to PSR-4 autoloading


### PR DESCRIPTION
The zicht:messages:load statement fills the entire screen with output.  This is now significantly less so.