### PR TITLE
Make sure Translator::doLoadCatalogue processes our custom entries last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 5.0.3 - 2020-08-28
+### Fixed
+- Added a Compiler Pass to place the .db files last to have the database entries processed last (to override existing messages)
+
 ## 5.0.2 - 2020-07-13
 ### Fixed
 - Forward merge from 4.1.3

--- a/src/DependencyInjection/Compiler/ReorderTranslationResourceFilesPass.php
+++ b/src/DependencyInjection/Compiler/ReorderTranslationResourceFilesPass.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\MessagesBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ReorderTranslationResourceFilesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        /* This Compiler Pass is searching for .db translation files to place them at the end
+           This will cause the Message Catalogue to load these resources as last and thus
+           the effect of overriding messages is maintained
+         */
+        $translator = $container->findDefinition('translator.default');
+        $options = $translator->getArgument(4);
+        $resourceFilesByLocale =& $options['resource_files'];
+
+        foreach (array_keys($resourceFilesByLocale) as $locale) {
+            uksort(
+                $resourceFilesByLocale[$locale],
+                function ($keyA, $keyB) use ($resourceFilesByLocale, $locale) {
+                    $fileA = $resourceFilesByLocale[$locale][$keyA];
+                    $fileB = $resourceFilesByLocale[$locale][$keyB];
+                    if (substr($fileA, -3) === '.db' && substr($fileB, -3) !== '.db') {
+                        return 1;
+                    }
+                    if (substr($fileB, -3) === '.db' && substr($fileA, -3) !== '.db') {
+                        return -1;
+                    }
+
+                    return $keyA < $keyB ? -1 : 1;
+                }
+            );
+        }
+
+        $translator->replaceArgument(4, $options);
+    }
+}

--- a/src/ZichtMessagesBundle.php
+++ b/src/ZichtMessagesBundle.php
@@ -1,17 +1,20 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\MessagesBundle;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Zicht\Bundle\MessagesBundle\DependencyInjection\Compiler\ReorderTranslationResourceFilesPass;
 
-/**
- * Class ZichtMessagesBundle
- *
- * @package Zicht\Bundle\MessagesBundle
- */
 class ZichtMessagesBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new ReorderTranslationResourceFilesPass());
+    }
 }


### PR DESCRIPTION
Volgens mij zorgt dit er voor dat onze database translations weer worden overschreven door de yaml variant.

Before
![image](https://user-images.githubusercontent.com/33859362/90610519-d2f1d780-e205-11ea-9ab5-0c83316186b3.png)

After
![image](https://user-images.githubusercontent.com/33859362/90610764-354ad800-e206-11ea-81f8-bc508015ce5a.png)

edit: hiervoor moeten ook de files hernoemd worden in de `/translations` directory in de projecten die deze versie gebruiken en de cookiecutter.

