### PR TITLE
Rewrite translations loader

### DIFF
--- a/src/Command/CacheCommand.php
+++ b/src/Command/CacheCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace Zicht\Bundle\MessagesBundle\Command;
+
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\Reader\TranslationReaderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Zicht\Bundle\MessagesBundle\Helper\FlushCatalogueCacheHelper;
+
+class CacheCommand extends Command
+{
+    protected static $defaultName = 'zicht:messages:cache';
+
+    private $cacheDir;
+
+    private $loader;
+
+    private $translationReader;
+
+    private $flusher;
+
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator, FlushCatalogueCacheHelper $flushCatalogueCacheHelper, TranslationReaderInterface $translationReader, LoaderInterface $loader, string $cacheDir, string $name = null)
+    {
+        parent::__construct($name);
+        $this->cacheDir = $cacheDir;
+        $this->loader = $loader;
+        $this->translationReader = $translationReader;
+        $this->flusher = $flushCatalogueCacheHelper;
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output = new SymfonyStyle($input, $output);
+        try {
+            $this->loader->setEnabled(true);
+            $this->flusher->__invoke();
+            $this->translator->warmUp($this->cacheDir);
+            $this->loader->setEnabled(false);
+        } catch (\Exception $e) {
+            $output->writeln($e->getMessage());
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/src/DependencyInjection/ZichtMessagesExtension.php
+++ b/src/DependencyInjection/ZichtMessagesExtension.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Zicht\Bundle\MessagesBundle\Subscriber\RequestListener;
 
 /**
  * DI extension for messages bundle
@@ -24,9 +25,9 @@ class ZichtMessagesExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $config        = $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new XmlFileLoader($container, new FileLocator(array(__DIR__.'/../Resources/config/')));
+        $loader = new XmlFileLoader($container, new FileLocator(array(__DIR__ . '/../Resources/config/')));
         $loader->load('services.xml');
         $loader->load('admin.xml');
 
@@ -39,5 +40,9 @@ class ZichtMessagesExtension extends Extension
                 'setMessageManager',
                 array(new Reference('zicht_messages.manager'))
             );
+
+        if (!$container->getParameter('kernel.debug')) {
+            $container->removeDefinition(RequestListener::class);
+        }
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -31,7 +31,6 @@
             <argument type="service" id="translation.loader.zicht_messages"/>
             <argument type="service" id="translator"/>
             <argument>%kernel.cache_dir%</argument>
-            <argument>%zicht_messages.entity%</argument>
         </service>
 
         <service id="zicht_messages.flush_cache_helper" class="Zicht\Bundle\MessagesBundle\Helper\FlushCatalogueCacheHelper">
@@ -93,6 +92,14 @@
         </service>
 
         <service id="Zicht\Bundle\MessagesBundle\Translator\MessageTranslator"/>
+
+        <!-- this listener is removed on non-debug envs -->
+        <service id="Zicht\Bundle\MessagesBundle\Subscriber\RequestListener" autowire="true">
+            <argument key="$loader" type="service" id="translation.loader.zicht_messages"/>
+            <argument key="$flusher" type="service" id="zicht_messages.flush_cache_helper"/>
+            <argument key="$cacheDir" type="string">%kernel.cache_dir%</argument>
+            <tag name="kernel.event_listener" event="kernel.request"/>
+        </service>
 
    </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -28,6 +28,9 @@
         <service id="translation.message_update_subscriber" class="Zicht\Bundle\MessagesBundle\Subscriber\FlushCatalogueCacheSubscriber">
             <tag name="doctrine.event_subscriber" connection="default"/>
             <argument type="service" id="zicht_messages.flush_cache_helper"/>
+            <argument type="service" id="translation.loader.zicht_messages"/>
+            <argument type="service" id="translator"/>
+            <argument>%kernel.cache_dir%</argument>
             <argument>%zicht_messages.entity%</argument>
         </service>
 
@@ -63,6 +66,15 @@
             <argument type="service" id="zicht_messages.manager"/>
             <argument type="service" id="translator"/>
             <argument>%kernel.project_dir%</argument>
+        </service>
+
+        <service id="Zicht\Bundle\MessagesBundle\Command\CacheCommand">
+            <tag name="console.command"/>
+            <argument type="service" id="translator"/>
+            <argument type="service" id="zicht_messages.flush_cache_helper"/>
+            <argument type="service" id="translation.reader"/>
+            <argument type="service" id="translation.loader.zicht_messages"/>
+            <argument>%kernel.cache_dir%</argument>
         </service>
 
         <service id="Zicht\Bundle\MessagesBundle\Command\FlushCommand">

--- a/src/Resources/translations/admin.nl.yml
+++ b/src/Resources/translations/admin.nl.yml
@@ -8,17 +8,17 @@ breadcrumb:
     link_message_list: Vertaling lijst
 filter:
     label_domain: Vertaling domein
-    label_message: Template titel
+    label_message: Bericht
 form:
     label_domain: Vertaling domein
     label_locale: Taal
-    label_message: Template titel
+    label_message: Bericht
     label_state: Status
     label_translation: Vertaling
     label_translations: Vertalingen
 list:
     label_domain: Vertaling domein
-    label_message: Template titel
+    label_message: Bericht
 message:
     state:
         import: Geimporteerd

--- a/src/Subscriber/RequestListener.php
+++ b/src/Subscriber/RequestListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Zicht\Bundle\MessagesBundle\Subscriber;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Zicht\Bundle\MessagesBundle\Helper\FlushCatalogueCacheHelper;
+
+class RequestListener
+{
+    private string $cacheDir;
+
+    private $loader;
+
+    private $flusher;
+
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator, LoaderInterface $loader, FlushCatalogueCacheHelper $flusher, string $cacheDir)
+    {
+        $this->translator = $translator;
+        $this->loader = $loader;
+        $this->flusher = $flusher;
+        $this->cacheDir = $cacheDir;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $fs = new Filesystem();
+        $fs->mkdir($this->cacheDir . '/translations');
+
+        $file = $this->cacheDir . '/translations/__zicht_init';
+        if ($fs->exists($file)) {
+            return;
+        }
+
+        $fs->dumpFile($file, (new \DateTime())->format('c'));
+
+        $this->loader->setEnabled(true);
+        $this->flusher->__invoke();
+        $this->translator->warmUp($this->cacheDir);
+        $this->loader->setEnabled(false);
+    }
+}


### PR DESCRIPTION
Fix #25

Hiermee is er dus geen automatische cache-herschrijf actie meer bij een cache-clear en moeten we gaan wennen aan het gebruik van een separaat commando `zicht:messages:cache`

Ideeen @7ochem @boudewijn-zicht ?