### PR TITLE
Fix commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 5.2.1 - 2022-05-02
+### Fixed
+- Fixed commands
+- Pass root name to TreeBuilder constructor and call `getRootNode` instead of deprecated `->root()`
+
 ## 5.2.0 - 2021-12-07
 ### Added
 - Support for PHP 8

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "zicht/messages-bundle",
     "description": "Zicht Messages bundle",
+    "license": "MIT",
     "authors": [
         {
             "name": "Zicht online",
@@ -9,10 +10,11 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
+        "doctrine/orm": "^2.5",
         "sonata-project/admin-bundle": "^3.35",
-        "symfony/yaml": "^4.4",
+        "symfony/console": "^4.4",
         "symfony/finder": "^4.4",
-        "doctrine/orm": "^2.5"
+        "symfony/yaml": "^4.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^8"
@@ -23,19 +25,14 @@
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
-            "Zicht\\Bundle\\MessagesBundle\\": [
-                "src/"
-            ]
+            "Zicht\\Bundle\\MessagesBundle\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Zicht\\Bundle\\MessagesBundle\\": [
-                "tests/"
-            ]
+            "Zicht\\Bundle\\MessagesBundle\\": "tests/"
         }
     },
-    "license": "MIT",
     "scripts": {
         "test": [
             "phpunit -c phpunit.xml.dist"

--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -5,7 +5,6 @@
 
 namespace Zicht\Bundle\MessagesBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -5,7 +5,7 @@
 
 namespace Zicht\Bundle\MessagesBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -16,7 +16,7 @@ use Zicht\Bundle\MessagesBundle\Translation\Loader;
 /**
  * Add a message to the database message catalogue.
  */
-class DumpCommand extends ContainerAwareCommand
+class DumpCommand extends Command
 {
     protected static $defaultName = 'zicht:messages:dump';
 
@@ -29,9 +29,7 @@ class DumpCommand extends ContainerAwareCommand
         $this->loader = $loader;
     }
 
-    /**
-     * @{inheritDoc}
-     */
+    /** {@inheritDoc} */
     public function configure()
     {
         $this
@@ -41,14 +39,10 @@ class DumpCommand extends ContainerAwareCommand
             ->addOption('format', '', InputOption::VALUE_REQUIRED, 'The output format to use', 'yml');
     }
 
-    /**
-     * @{inheritDoc}
-     */
+    /** {@inheritDoc} */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var $loader \Zicht\Bundle\MessagesBundle\Translation\Loader */
-        $loader = $this->loader;
-        $catalogue = $loader->load('', $input->getArgument('locale'), $input->getArgument('domain'));
+        $catalogue = $this->loader->load('', $input->getArgument('locale'), $input->getArgument('domain'));
 
         $messages = $catalogue->all($input->getArgument('domain'));
 

--- a/src/Command/FlushCommand.php
+++ b/src/Command/FlushCommand.php
@@ -5,7 +5,6 @@
 
 namespace Zicht\Bundle\MessagesBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Command/TranslateCommand.php
+++ b/src/Command/TranslateCommand.php
@@ -10,22 +10,15 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Translation\Loader\ArrayLoader;
-use Symfony\Component\Translation\Util\XliffUtils;
-use Symfony\Component\Yaml\Yaml;
-use Zicht\Bundle\MessagesBundle\Translator\BatchTranslatorInterface;
 use Zicht\Bundle\MessagesBundle\Translator\MessageTranslator;
-use Zicht\Bundle\MessagesBundle\Translator\Replacer;
 
 class TranslateCommand extends Command
 {
     /** @var string */
     protected static $defaultName = 'zicht:messages:translate';
-    /**
-     * @var MessageTranslator
-     */
+
+    /** @var MessageTranslator */
     private $translator;
 
     public function __construct(MessageTranslator $translator, string $name = null)
@@ -34,9 +27,7 @@ class TranslateCommand extends Command
         $this->translator = $translator;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     protected function configure()
     {
         $this
@@ -45,9 +36,7 @@ class TranslateCommand extends Command
             ->addOption('--target', '-t', InputOption::VALUE_OPTIONAL, 'The target-language. Override if auto-discovered target is not in line with your translation API specs.');
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->translator->translate(new File($input->getArgument('file')), $input->getOption('source'), $input->getOption('target'));

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,13 +13,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * @{inheritDoc}
-     */
+    /** {@inheritDoc} */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('zicht_messages');
+        $treeBuilder = new TreeBuilder('zicht_messages');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
Most important changes:

- In `src/Command/DumpCommand.php`:
    ```diff
    -class DumpCommand extends ContainerAwareCommand
    +class DumpCommand extends Command
    ```
- Added `"symfony/console": "^4.4",` in `composer.json`
- Pass root name to TreeBuilder constructor and call `getRootNode` instead of deprecated `->root()` in `src/DependencyInjection/Configuration.php`
