### PR TITLE
[fix] Fix error when using multiple filters in messages admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 7.1.1 - 2023-04-17
+### Fixed
+- Error when using 3 filters simultaneously
+
 ## 7.1.0 - 2022-12-07
 ### Added
 - Support for `doctrine/dbal ^3`

--- a/src/Admin/MessageAdmin.php
+++ b/src/Admin/MessageAdmin.php
@@ -144,12 +144,12 @@ class MessageAdmin extends AbstractAdmin
             return;
         }
 
-        $queryBuilder->leftJoin(sprintf('%s.translations', $alias), 't');
+        $queryBuilder->leftJoin(sprintf('%s.translations', $alias), 't1');
 
         $queryBuilder->andWhere(
             $queryBuilder->expr()->orX(
                 $queryBuilder->expr()->like('o.message', ':tr'),
-                $queryBuilder->expr()->like('t.translation', ':tr')
+                $queryBuilder->expr()->like('t1.translation', ':tr')
             )
         );
 
@@ -172,8 +172,8 @@ class MessageAdmin extends AbstractAdmin
         }
 
         $queryBuilder
-            ->leftJoin(sprintf('%s.translations', $alias), 't')
-            ->andWhere($queryBuilder->expr()->eq('t.state', ':status'))
+            ->leftJoin(sprintf('%s.translations', $alias), 't2')
+            ->andWhere($queryBuilder->expr()->eq('t2.state', ':status'))
             ->setParameter('status', $value->getValue());
         return true;
     }


### PR DESCRIPTION
**Example site with bug**
gritco.nl

**Version**
7.1.0

**Steps to reproduce**
1) go to "Other / Translations"
2) Use all 3 filter types: "Message domain", "Message", "State"

**Error message**
```
An exception has been thrown during the rendering of a template ("[Semantical Error] line 0, col 111 near 't WHERE o.domain': Error: 't' is already defined.").
```

**Query**
```
SELECT o FROM Zicht\Bundle\MessagesBundle\Entity\Message o 
LEFT JOIN o.translations t 
LEFT JOIN o.translations t 
WHERE o.domain LIKE :domain_0 
AND (o.message LIKE :tr OR t.translation LIKE :tr) 
AND t.state = :status 
ORDER BY o.id ASC
```
**message admin filters**
![image](https://user-images.githubusercontent.com/89969537/232485855-cc11e251-ac7c-42ef-b260-1d9674b33a80.png)

